### PR TITLE
Set up CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,3 +15,5 @@ workflows:
           registry: quay.io
           image: upennlibraries/discovery-app
           label_prefix: edu.upenn.library
+          requires:
+            - gitleaks/check_local


### PR DESCRIPTION
We're now using CircleCI to check the repo for secrets and to build / publish the Docker image. 🐉 