### PR TITLE
temporarily add links to hathi records corresponding to local holdings

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -134,7 +134,7 @@ class CatalogController < ApplicationController
         'facet.mincount': 0,
         #      fq: '{!tag=cluster}{!collapse field=cluster_id nullPolicy=expand size=5000000 min=record_source_id}',
         # this approach needs expand.field=cluster_id
-        fq: %q~{!tag=cluster}NOT ({!join from=cluster_id to=cluster_id v='record_source_f:"Penn"'} AND record_source_f:"HathiTrust")~,
+        fq: %q~{!tag=cluster}NOT ({!join from=cluster_id to=cluster_id v='record_source_f:"Penn"'} AND record_source_f:"HathiTrust") NOT record_source_id:3~,
         expand: 'true',
         'expand.field': 'cluster_id',
         'expand.q': '*:*',
@@ -298,11 +298,11 @@ class CatalogController < ApplicationController
             'Other' => { :label => 'Other', :fq => "{!tag=azlist ex=azlist}title_xfacet:/[ -`{-~].*/"}
         }
     config.add_facet_field 'access_f', label: 'Access', collapse: false, solr_params: @@MINCOUNT, query: {
-        'Online' => { :label => 'Online', :fq => "{!join from=cluster_id to=cluster_id v='{!term f=access_f v=\\'Online\\'}'}"},
+        'Online' => { :label => 'Online', :fq => "{!join from=cluster_id to=cluster_id v='access_f:Online OR record_source_id:3'}"},
         'At the library' => { :label => 'At the library', :fq => "{!join from=cluster_id to=cluster_id v='{!term f=access_f v=\\'At the library\\'}'}"}
     }
     config.add_facet_field 'record_source_f', label: 'Record Source', collapse: false, solr_params: @@MINCOUNT, query: {
-        'HathiTrust' => { :label => 'HathiTrust', :fq => "{!join from=cluster_id to=cluster_id v='{!term f=record_source_f v=\\'HathiTrust\\'}'}"},
+        'HathiTrust' => { :label => 'HathiTrust', :fq => "{!join from=cluster_id to=cluster_id v='{!terms f=record_source_id v=2,3}'}"},
         'Penn' => { :label => 'Penn', :fq => "{!join from=cluster_id to=cluster_id v='{!term f=record_source_f v=\\'Penn\\'}'}"}
     }
     config.add_facet_field 'format_f', label: 'Format', limit: 5, collapse: false, solr_params: @@MINCOUNT

--- a/app/helpers/document_render_helper.rb
+++ b/app/helpers/document_render_helper.rb
@@ -51,12 +51,20 @@ module DocumentRenderHelper
     end
   end
 
+  @@HATHI_TMP_TEXT = 'HathiTrust Digital Library Login for full text'
+  @@HATHI_REPLACEMENT_TEXT = 'COVID-19 Special Access from HathiTrust — Login for full text'
+  @@HATHI_LOGIN_PREFIX = 'https://babel.hathitrust.org/Shibboleth.sso/Login?entityID=https://idp.pennkey.upenn.edu/idp/shibboleth&target=https%3A%2F%2Fbabel.hathitrust.org%2Fcgi%2Fping%2Fpong%3Ftarget%3D'
+
   def render_online_resource_display_for_index_view(options)
     values = options[:value]
     values.map do |value|
       JSON.parse(value).map do |link_struct|
         url = link_struct['linkurl']
         text = link_struct['linktext']
+        if text == @@HATHI_TMP_TEXT
+          text = @@HATHI_REPLACEMENT_TEXT
+          url = @@HATHI_LOGIN_PREFIX + URI.encode_www_form_component(url)
+        end
         %Q{<a href="#{url}">#{text}</a>}
       end.join('<br/>')
     end.join('<br/>').html_safe
@@ -69,11 +77,16 @@ module DocumentRenderHelper
       JSON.parse(value).map do |link_struct|
         url = link_struct['linkurl']
         text = link_struct['linktext']
+        orig_url = url
+        if text == @@HATHI_TMP_TEXT
+          text = @@HATHI_REPLACEMENT_TEXT
+          url = @@HATHI_LOGIN_PREFIX + URI.encode_www_form_component(url)
+        end
         html = %Q{<div class="online-resource-link-group"><a href="#{url}">#{text}</a>}
         html += '<br/>'.html_safe
 
         if !text.start_with?('http')
-          html += + url
+          html += + orig_url
         end
 
         if link_struct['volumes']

--- a/app/views/catalog/_show_expanded.html.erb
+++ b/app/views/catalog/_show_expanded.html.erb
@@ -1,4 +1,4 @@
-<% if document.expanded_docs.size > 0 %>
+<% if document.expanded_docs.select { |doc| !doc.id.start_with?('HATHIALL_') }.size > 0 %>
     <dt class="blacklight-other_records">
       Other records:
     </dt>
@@ -7,7 +7,7 @@
         <div class="form-group">
           <select class="form-control document-cluster-select">
             <option>Select one...</option>
-            <% document.all_doc_ids_for_cluster.sort.each do |doc_id| %>
+            <% document.all_doc_ids_for_cluster.select { |doc_id| !doc_id.start_with?('HATHIALL_') }.sort.each do |doc_id| %>
                 <option value="<%= doc_id %>"><%= doc_id %><%= document.id == doc_id ? ' (currently shown)' : '' %></option>
             <% end %>
           </select>


### PR DESCRIPTION
This can be deployed over the extant index with no immediate effect. New links depend on presence of hathi pseudo-records in index. Index with these records can be swapped into place at any time, enabling new linking functionality.