### PR TITLE
Add online_reserve facet for conditional availability handling

### DIFF
--- a/app/helpers/document_render_helper.rb
+++ b/app/helpers/document_render_helper.rb
@@ -76,14 +76,15 @@ module DocumentRenderHelper
         if text == @@HATHI_PD_TEXT
           hathi_pd = true
         elsif text == @@HATHI_TMP_TEXT
+          next if options[:document][:online_reserve_f]&.include?('2020FALL')
           hathi_etas = true
           text = @@HATHI_REPLACEMENT_TEXT
           url = @@HATHI_LOGIN_PREFIX + URI.encode_www_form_component(url)
           append = @@HATHI_INFO
         end
         %Q{<a href="#{url}">#{text}</a>#{append}}
-      end.join('<br/>')
-    end.join('<br/>')
+      end.compact.join('<br/>').presence
+    end.compact.join('<br/>')
     unless alma_mms_id.nil?
       if hathi_pd
         ret = ret.concat(hathi_tag_id('pd', alma_mms_id))
@@ -109,6 +110,7 @@ module DocumentRenderHelper
         if text == @@HATHI_PD_TEXT
           hathi_pd = true
         elsif text == @@HATHI_TMP_TEXT
+          next if options[:document][:online_reserve_f]&.include?('2020FALL')
           hathi_etas = true
           text = @@HATHI_REPLACEMENT_TEXT
           url = @@HATHI_LOGIN_PREFIX + URI.encode_www_form_component(url)

--- a/app/models/franklin_indexer.rb
+++ b/app/models/franklin_indexer.rb
@@ -166,6 +166,10 @@ class FranklinIndexer < BaseIndexer
       acc.concat(pennlibmarc.get_db_subcategories(rec))
     end
 
+    to_field "online_reserve_f" do |rec, acc|
+      acc.concat(pennlibmarc.get_online_reserve_f(rec))
+    end
+
     to_field 'subject_search' do |rec, acc|
       acc.concat(pennlibmarc.get_subject_search_values(rec))
     end

--- a/lib/penn_lib/marc.rb
+++ b/lib/penn_lib/marc.rb
@@ -430,6 +430,15 @@ module PennLib
       end.compact
     end
 
+    def get_online_reserve_f(rec)
+      rec.fields('943').map do |field|
+        if field.any? { |sf| sf.code == '2' && sf.value == 'online_reserve' }
+          sf = field.find { |sf| sf.code == 'a' }
+          sf.nil? ? nil : sf.value
+        end
+      end.compact
+    end
+
     def get_subject_facet_values(rec, toplevel_only = false)
       rec.fields.find_all { |f| is_subject_field(f) }.map do |field|
         just_a = nil


### PR DESCRIPTION
This may be deployed at any time (aside from the caveat about cached join filters below!); it will have no functional effect until 943a for designated records is populated with special values.

To specify multiple values, 943 field should be repeated. 943 is not inspected by the indexing code for multiple subfield "a"s. _If_ multiple subfield "a"s is valid MARC, perhaps this should be changed, so that any configuration of the field that is valid MARC will also behave downstream as intuitively expected?

NOTE: PERFORMANCE RELIES ON CACHED JOIN FILTERS! before production deployment, must update solrconfig.xml warming queries corresponding to the changed facet queries.