### PR TITLE
first-pass refinement of specialist queries

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -105,6 +105,7 @@ class CatalogController < ApplicationController
         defType: 'perEndPosition_dense_shingle_graphSpans',
         combo: '{!filters param=$q param=$fq excludeTags=cluster}',
         post_1928: 'content_max_dtsort:[1929-01-01T00:00:00Z TO *]',
+        culture_filter: "{!bool should='{!terms f=subject_search v=literature,customs,religion,ethics,society,social,culture,cultural}' should='{!prefix f=subject_search v=art}'}",
         #combo: '{!bool must=$q filter=\'{!filters param=$fq v=*:*}\'}',
         #combo: '{!query v=$q}',
         back: '*:*',

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -232,7 +232,8 @@ class CatalogController < ApplicationController
     }
 
     @@SUBJECT_SPECIALISTS = File.open("config/translation_maps/subject_specialists.solr-json", "rb").map do |line|
-      line.strip
+      comment_idx = line.index('#')
+      (comment_idx.nil? ? line : line.slice(0, comment_idx)).strip.presence
     end.compact.join
 
     @@DATABASE_CATEGORY_TAXONOMY = [

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -104,6 +104,7 @@ class CatalogController < ApplicationController
         #cache: 'false',
         defType: 'perEndPosition_dense_shingle_graphSpans',
         combo: '{!filters param=$q param=$fq excludeTags=cluster}',
+        post_1928: 'content_max_dtsort:[1929-01-01T00:00:00Z TO *]',
         #combo: '{!bool must=$q filter=\'{!filters param=$fq v=*:*}\'}',
         #combo: '{!query v=$q}',
         back: '*:*',

--- a/config/translation_maps/subject_specialists.solr-json
+++ b/config/translation_maps/subject_specialists.solr-json
@@ -5,7 +5,7 @@
     facet:{
   accounting : {
     type: query,
-    q: "{!term f=subject_search v=accounting}",
+    q: "{!bool filter='{!term f=subject_search v=accounting}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -82,7 +82,7 @@
   },
   biology : {
     type: query,
-    q: "{!term f=subject_search v=biology}",
+    q: "{!bool filter='{!term f=subject_search v=biology}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -110,7 +110,7 @@
   },
   chemistry : {
     type: query,
-    q: "{!term f=subject_search v=chemistry}",
+    q: "{!bool filter='{!term f=subject_search v=chemistry}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -138,7 +138,7 @@
   },
   communication : {
     type: query,
-    q: "{!term f=subject_search v=communication}",
+    q: "{!bool filter='{!term f=subject_search v=communication}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -152,14 +152,14 @@
   },
   criminology : {
     type: query,
-    q: "{!term f=subject_search v=criminology}",
+    q: "{!bool filter='{!term f=subject_search v=criminology}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
   },
   dental_medicine : {
     type: query,
-    q: "{!prefix f=subject_f v='Dentistry'}",
+    q: "{!bool filter='{!prefix f=subject_f v=Dentistry}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -180,7 +180,7 @@
   },
   education : {
     type: query,
-    q: "{!term f=subject_search v=education}",
+    q: "{!bool filter='{!term f=subject_search v=education}' must_not='{!term f=subject_f v=\\'Health education\\'}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -194,14 +194,14 @@
   },
   entrepreneurship : {
     type: query,
-    q: "{!term f=subject_search v=entrepreneurship}",
+    q: "{!bool filter='{!term f=subject_search v=entrepreneurship}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
   },
   finance : {
     type: query,
-    q: "{!term f=subject_search v=finance}",
+    q: "{!bool filter='{!term f=subject_search v=finance}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -236,7 +236,7 @@
   },
   general_science : {
     type: query,
-    q: "{!prefix f=subject_f v=Science}",
+    q: "{!bool filter='{!prefix f=subject_f v=Science}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -257,7 +257,7 @@
   },
   health_care_management : {
     type: query,
-    q: "{!bool filter='{!term f=subject_search v=health}' filter='{!term f=subject_search v=care}' should='{!term f=subject_search v=management}' should='{!term f=subject_search v=economics}'}",
+    q: "{!bool filter='{!term f=subject_search v=health}' filter='{!term f=subject_search v=care}' filter='{!terms f=subject_search v=management,economics}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -292,7 +292,7 @@
   },
   international_business : {
     type: query,
-    q: "{!bool filter='{!term f=subject_search v=international}' filter='{!term f=subject_search=business}'}",
+    q: "{!bool filter='{!term f=subject_search v=international}' filter='{!term f=subject_search=business}' filter=$post_1928}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -397,7 +397,7 @@
   },
   marketing : {
     type: query,
-    q: "{!term f=subject_search v=marketing}",
+    q: "{!bool filter='{!term f=subject_search v=marketing}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -411,21 +411,21 @@
   },
   medicine : {
     type: query,
-    q: "{!term f=subject_search v=medicine}",
+    q: "{!bool filter='{!term f=subject_search v=medicine}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
   },
   medieval_manuscripts : {
     type: query,
-    q: "{!bool filter='{!term f=subject_search v=medieval}' filter='{!terms f=subject_search v=manuscript,manuscripts}'}",
+    q: "{!bool filter='{!bool should=\\'{!term f=subject_search v=medieval}\\' should=\\'content_min_dtsort:[* TO 1600-01-01T00:00:00Z]\\'}' filter='{!terms f=subject_search v=manuscript,manuscripts}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
   },
   medieval_studies : {
     type: query,
-    q: "{!term f=subject_search v=medieval}",
+    q: "{!bool should='{!term f=subject_search v=medieval}' should='content_min_dtsort:[* TO 1600-01-01T00:00:00Z]'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -439,14 +439,14 @@
   },
   modern_manuscripts_amp_archives : {
     type: query,
-    q: "{!bool should='{!terms f=subject_search v=archive,archives}' should='{!bool filter=\\'{!term f=subject_search v=modern}\\' filter=\\'{!terms f=subject_search v=manuscript,manuscripts}\\'}'}",
+    q: "{!bool should='{!term f=format_f v=Archive}' should='{!bool filter=\\'{!term f=subject_search v=modern}\\' should=\\'content_max_dtsort:[1601-01-01T00:00:00Z TO *]\\' filter=\\'{!terms f=subject_search v=manuscript,manuscripts}\\'}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
   },
   music : {
     type: query,
-    q: "{!term f=subject_search v=music}",
+    q: "{!bool should='{!term f=subject_search v=music}' should='{!terms f=format_f v=\\'Sound recording,Musical score\\'}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -509,7 +509,7 @@
   },
   political_science_data : {
     type: query,
-    q: "{!bool filter='{!prefix f=subject_f v=\\'Political science\\'}' filter='{!term f=subject_search v=data}'}",
+    q: "{!bool filter='{!prefix f=subject_search v=politic}' filter='{!term f=subject_search v=data}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -530,7 +530,7 @@
   },
   real_estate : {
     type: query,
-    q: "{!bool should='{!prefix f=subject_f v=\\'Real estate\\'}' should='{!prefix f=subject_f v=\\'Real property\\'}'}",
+    q: "{!bool should='{!prefix f=subject_f v=\\'Real estate\\'}' should='{!prefix f=subject_f v=\\'Real property\\'}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -621,7 +621,7 @@
   },
   statistics : {
     type: query,
-    q: "{!term f=subject_search v=statistics}",
+    q: "{!bool filter='{!term f=subject_search v=statistics}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -642,7 +642,7 @@
   },
   veterinary_medicine : {
     type: query,
-    q: "{!term f=subject_search v=veterinary}",
+    q: "{!bool filter='{!term f=subject_search v=veterinary}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }

--- a/config/translation_maps/subject_specialists.solr-json
+++ b/config/translation_maps/subject_specialists.solr-json
@@ -124,7 +124,7 @@
   },
   cinema_amp_media_studies : {
     type: query,
-    q: "{!bool should='{!complexphrase df=subject_search v=\\'\"motion (picture pictures)\"\\'}' should='{!terms f=subject_search v=media,cinema}' should='{!term f=format_f v=Video}'}",
+    q: "{!bool should='{!complexphrase df=subject_search v=\\'\"motion (picture pictures)\"\\'}' should='{!terms f=subject_search v=media,cinema}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }

--- a/config/translation_maps/subject_specialists.solr-json
+++ b/config/translation_maps/subject_specialists.solr-json
@@ -124,7 +124,7 @@
   },
   cinema_amp_media_studies : {
     type: query,
-    q: "{!bool should='{!term f=subject_search v=cinema}' should='{!term f=subject_search v=media}'}",
+    q: "{!bool should='{!complexphrase df=subject_search v=\\'\"motion (picture pictures)\"\\'}' should='{!terms f=subject_search v=media,cinema}' should='{!term f=format_f v=Video}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }

--- a/config/translation_maps/subject_specialists.solr-json
+++ b/config/translation_maps/subject_specialists.solr-json
@@ -250,7 +250,7 @@
   },
   germanic_languages_amp_literatures : {
     type: query,
-    q: "{!bool filter='{!prefix f=subject_search v=german}' should='{!prefix f=subject_search v=language}' should='{!term f=subject_search v=literature}'}",
+    q: "{!bool filter='{!prefix f=subject_search v=german}' filter='{!bool should=\\'{!prefix f=subject_search v=language}\\' should=\\'{!term f=subject_search v=literature}\\'}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -264,7 +264,7 @@
   },
   historic_preservation : {
     type: query,
-    q: "{!bool filter='{!term f=subject_search v=historic}' should='{!term f=subject_search v=preservation}' should='{!term f=subject_search v=conservation}' should='{!term f=subject_search v=restoration}'}",
+    q: "{!bool filter='{!term f=subject_search v=historic}' filter='{!bool should=\\'{!term f=subject_search v=preservation}\\' should=\\'{!term f=subject_search v=conservation}\\' should=\\'{!term f=subject_search v=restoration}\\'}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -306,7 +306,7 @@
   },
   italian_language_amp_literature : {
     type: query,
-    q: "{!bool filter='{!term f=subject_search v=italian}' should='{!term f=subject_search v=language}' should='{!term f=subject_search v=literature}'}",
+    q: "{!bool filter='{!term f=subject_search v=italian}' filter='{!bool should=\\'{!term f=subject_search v=language}\\' should=\\'{!term f=subject_search v=literature}\\'}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -376,7 +376,7 @@
   },
   literature_in_english : {
     type: query,
-    q: "{!bool should='{!term f=language_f v=English}' should='{!term f=subject_search v=english}' filter='{!term f=subject_search v=literature}'}",
+    q: "{!bool filter='{!bool should=\\'{!term f=language_f v=English}\\' should=\\'{!term f=subject_search v=english}\\'}' filter='{!term f=subject_search v=literature}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -439,7 +439,7 @@
   },
   modern_manuscripts_amp_archives : {
     type: query,
-    q: "{!bool should='{!term f=format_f v=Archive}' should='{!bool filter=\\'{!term f=subject_search v=modern}\\' should=\\'content_max_dtsort:[1601-01-01T00:00:00Z TO *]\\' filter=\\'{!terms f=subject_search v=manuscript,manuscripts}\\'}'}",
+    q: "{!bool filter='{!bool should=\\'{!term f=format_f v=Archive}\\' should=\\'{!terms f=subject_search v=manuscript,manuscripts}\\'}' filter='content_max_dtsort:[1601-01-01T00:00:00Z TO *]'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -523,14 +523,14 @@
   },
   rare_books_amp_printed_materials : {
     type: query,
-    q: "{!bool should='{!bool must=\\'{!term f=library_f v=\\\\\\'Special Collections\\\\\\'}\\' must_not=\\'{!term f=format_f v=Manuscript}\\'}' should='{!prefix f=subject_f v=\\'Rare books\\'}'}",
+    q: "{!bool should='{!bool filter=\\'{!term f=library_f v=\\\\\\'Special Collections\\\\\\'}\\' must_not=\\'{!term f=format_f v=Manuscript}\\'}' should='{!prefix f=subject_f v=\\'Rare books\\'}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
   },
   real_estate : {
     type: query,
-    q: "{!bool should='{!prefix f=subject_f v=\\'Real estate\\'}' should='{!prefix f=subject_f v=\\'Real property\\'}' filter=$post_1928 }",
+    q: "{!bool filter='{!complexphrase df=subject_search v=\\'\"real (estate property)\"\\'}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }

--- a/config/translation_maps/subject_specialists.solr-json
+++ b/config/translation_maps/subject_specialists.solr-json
@@ -320,14 +320,14 @@
   },
   judaica_special_collections : {
     type: query,
-    q: "{!bool filter='{!term f=library_f v=\\'Special Collections\\'}' filter='{!terms f=subject_search v=jews,jewish}'}",
+    q: "{!bool filter='{!term f=library_f v=\\'Special Collections\\'}' filter='{!terms f=subject_search v=judaism,jews,jewish}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
   },
   judaic_studies : {
     type: query,
-    q: "{!terms f=subject_search v=jews,jewish}",
+    q: "{!bool filter='{!bool should=\\'{!terms f=subject_search v=judaism,jews}\\' should=\\'{!prefix f=subject_f v=Jewish}\\'}' filter=$culture_filter}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }

--- a/config/translation_maps/subject_specialists.solr-json
+++ b/config/translation_maps/subject_specialists.solr-json
@@ -1,16 +1,30 @@
+# inline comments are supported for the purpose of documenting these sometimes-convoluted
+# queries inline. The comments are somewhat naively stripped out when read
+# into ruby. This means that if you need to use a literal '#' for some reason,
+# you'll have to make special accommodations at the point where this file is read
+# into ruby. For now, we're not going to support literal '#' speculatively ...
+
 {
   subject_specialists: {
+    # the only purpose served by this top-level of hierarchy is to group the nested facet
+    # queries, where the real "work" happens. This allows them to be easily parsed, disabled,
+    # etc. as a group.
     type: query,
     q: '*:*',
     facet:{
   accounting : {
     type: query,
+    # this domain (and some others) are implicitly focused on more recent content. The
+    # post_1928 filter is a somewhat arbitrary date restriction to narrow the focus of
+    # these domains; $post_1928 query is defined in catalog controller, default solr params
     q: "{!bool filter='{!term f=subject_search v=accounting}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
   },
   africana_studies : {
+    # "africana" is a general term that is more likely to appear in the record at large
+    # than in an official "subject" field, so we inspect the catch-all marcrecord_xml field
     type: query,
     q: "{!term f=marcrecord_xml v=africana}",
     facet: {
@@ -40,6 +54,7 @@
   },
   architectural_history : {
     type: query,
+    # prefix searches on subject_f are good for capturing a heading and all associated subheadings
     q: "{!prefix f=subject_f v=Architecture--History}",
     facet: {
       r1 : "relatedness($combo,$back)"
@@ -61,6 +76,7 @@
   },
   asian_american_studies : {
     type: query,
+    # "double quoted" search yields a phrase search
     q: "{!field f=subject_search v='\"asian american\"'}",
     facet: {
       r1 : "relatedness($combo,$back)"
@@ -82,6 +98,7 @@
   },
   biology : {
     type: query,
+    # see comment about $post_1928 under entry for "accounting"
     q: "{!bool filter='{!term f=subject_search v=biology}' filter=$post_1928 }",
     facet: {
       r1 : "relatedness($combo,$back)"
@@ -222,7 +239,9 @@
   },
   french_language_amp_literature : {
     type: query,
-    q: "{!bool filter='{!term f=subject_search v=french}' should='{!term f=subject_search v=language}' should='{!term f=subject_search v=literature}'}",
+    # match on "filter" clause means that no "should" clauses need to match; so we have to bundle the
+    # "should" clauses together as a top-level "filter" clause
+    q: "{!bool filter='{!term f=subject_search v=french}' filter='{!bool should=\\'{!term f=subject_search v=language}\\' should=\\'{!term f=subject_search v=literature}\\'}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -250,6 +269,7 @@
   },
   germanic_languages_amp_literatures : {
     type: query,
+    # see comment on mixed "filter" and "should" clauses under "french...", above
     q: "{!bool filter='{!prefix f=subject_search v=german}' filter='{!bool should=\\'{!prefix f=subject_search v=language}\\' should=\\'{!term f=subject_search v=literature}\\'}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
@@ -278,6 +298,8 @@
   },
   history_amp_sociology_of_science : {
     type: query,
+    # loose/"sloppy" proximity search is the most efficient way to catch the relevant subjects here, so we use edismax
+    # "political" caused a bunch of spurious matches, so we blacklist it
     q: "{!bool should='{!edismax qf=subject_search pf=subject_search v=\\'\"sociology science\"~5\\'}' should='{!edismax qf=subject_search pf=subject_search v=\\'\"history science\"~5\\'}' must_not='{!term f=subject_search v=political}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
@@ -285,6 +307,8 @@
   },
   humanities_general : {
     type: query,
+    # this is a huge domain, by design. But correlation will account for that and should
+    # only match this domain for very broad queries
     q: "{!terms f=subject_search v=anthropology,archaeology,classical,history,linguistics,language,law,politics,literature,philosophy,religion,art}",
     facet: {
       r1 : "relatedness($combo,$back)"
@@ -327,6 +351,11 @@
   },
   judaic_studies : {
     type: query,
+    # $culture_filter covers various markers pertaining to culture. It is general enough to be reused elsewhere
+    # (e.g., perhaps for the "language & literature" domains, though for now these are defined specifically wrt
+    # "language" and "literature"
+    # NOTE: better results were achieved with the more targeted "Jewish" prefix search than were achieved via
+    # simply including "jewish" in the "terms" query.
     q: "{!bool filter='{!bool should=\\'{!terms f=subject_search v=judaism,jews}\\' should=\\'{!prefix f=subject_f v=Jewish}\\'}' filter=$culture_filter}",
     facet: {
       r1 : "relatedness($combo,$back)"
@@ -383,6 +412,8 @@
   },
   management : {
     type: query,
+    # opted *not* to explicitly filter to $post_1928 here; unlike for "accounting" and "biology",
+    # this term should effectively self-select to more modern materials without extra filtering
     q: "{!term f=subject_search v=management}",
     facet: {
       r1 : "relatedness($combo,$back)"
@@ -404,7 +435,7 @@
   },
   mathematics : {
     type: query,
-    q: "{!term f=subject_search v=mathematics}",
+    q: "{!bool filter='{!term f=subject_search v=mathematics}' filter=$post_1928}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
@@ -418,6 +449,9 @@
   },
   medieval_manuscripts : {
     type: query,
+    # somewhat arbitrary date range delimiting "medieval" from "modern" mss.
+    # per fraas, early renaissance mss are usually bundled with medieval, hence
+    # the magic 1600 date
     q: "{!bool filter='{!bool should=\\'{!term f=subject_search v=medieval}\\' should=\\'content_min_dtsort:[* TO 1600-01-01T00:00:00Z]\\'}' filter='{!terms f=subject_search v=manuscript,manuscripts}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
@@ -425,6 +459,7 @@
   },
   medieval_studies : {
     type: query,
+    # see note above ("medieval manuscripts") wrt somewhat-arbitrary date range filter
     q: "{!bool should='{!term f=subject_search v=medieval}' should='content_min_dtsort:[* TO 1600-01-01T00:00:00Z]'}",
     facet: {
       r1 : "relatedness($combo,$back)"
@@ -439,6 +474,7 @@
   },
   modern_manuscripts_amp_archives : {
     type: query,
+    # see note above (under "medieval_manuscripts") re: arbitrary dividing line between "medieval+" and "modern" 
     q: "{!bool filter='{!bool should=\\'{!term f=format_f v=Archive}\\' should=\\'{!terms f=subject_search v=manuscript,manuscripts}\\'}' filter='content_max_dtsort:[1601-01-01T00:00:00Z TO *]'}",
     facet: {
       r1 : "relatedness($combo,$back)"
@@ -523,6 +559,8 @@
   },
   rare_books_amp_printed_materials : {
     type: query,
+    # per fraas, location-based domain should be ok. This will not be perfect for all cases, but
+    # "perfect for all cases" is not an attainable goal ...
     q: "{!bool should='{!bool filter=\\'{!term f=library_f v=\\\\\\'Special Collections\\\\\\'}\\' must_not=\\'{!term f=format_f v=Manuscript}\\'}' should='{!prefix f=subject_f v=\\'Rare books\\'}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
@@ -558,28 +596,28 @@
   },
   scholarly_publishing : {
     type: query,
-    q: "{!bool must='{!term f=subject_search v=scholarly}' must='{!term f=subject_search v=publishing}'}",
+    q: "{!bool filter='{!term f=subject_search v=scholarly}' filter='{!term f=subject_search v=publishing}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
   },
   social_impact : {
     type: query,
-    q: "{!bool must='{!term f=subject_search v=social}' must='{!terms f=subject_search v=economic,political,business,policy}'}",
+    q: "{!bool filter='{!term f=subject_search v=social}' filter='{!terms f=subject_search v=economic,political,business,policy}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
   },
   social_policy : {
     type: query,
-    q: "{!bool must='{!term f=subject_search v=social}' must='{!terms f=subject_search v=economic,political,business}' must='{!term f=subject_f v=policy}'}",
+    q: "{!bool filter='{!term f=subject_search v=social}' filter='{!terms f=subject_search v=economic,political,business}' filter='{!term f=subject_f v=policy}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }
   },
   social_science_data : {
     type: query,
-    q: "{!bool must='{!term f=subject_search v=social}' must='{!terms f=subject_search v=science,sciences}' must='{!terms f=subject_search v=data,methods,methodology,statistical,statistics}'}",
+    q: "{!bool filter='{!term f=subject_search v=social}' filter='{!terms f=subject_search v=science,sciences}' filter='{!terms f=subject_search v=data,methods,methodology,statistical,statistics}'}",
     facet: {
       r1 : "relatedness($combo,$back)"
     }


### PR DESCRIPTION
chiefly consists of restricting certain disciplines to post-1928;
somewhat arbitrary date, but for this purpose should suffice, and
provide a template for further date restriction revisions