### PR TITLE
properly reference path to custom font

### DIFF
--- a/app/assets/stylesheets/base/globals.css.scss
+++ b/app/assets/stylesheets/base/globals.css.scss
@@ -21,5 +21,5 @@ h4 {
 
 @font-face {
   font-family: "Gentium Book Basic";
-  src: url(/assets/GenBkBasR.ttf) format("truetype");
+  src: font_url("/assets/GenBkBasR.ttf") format("truetype");
 }


### PR DESCRIPTION
browser console showed that this font was not properly being referenced in the CSS, and therefore not used. I assume it was intended to be used.