### PR TITLE
Fix email handling

### DIFF
--- a/app/controllers/concerns/handle_empty_email.rb
+++ b/app/controllers/concerns/handle_empty_email.rb
@@ -8,7 +8,7 @@ module HandleEmptyEmail
 
   # override of method in Blacklight::Catalog
   def email_action(documents)
-    return unless documents.any?
+    return unless documents.any? && email_is_legit(params[:to])
 
     begin
       retries ||= 0
@@ -31,4 +31,10 @@ module HandleEmptyEmail
     super(documents)
   end
 
+  # Check if email address matches RegEx
+  # @param [String] email
+  # @return [Fixnum, nil]
+  def email_is_legit(email)
+    email =~ URI::MailTo::EMAIL_REGEXP
+  end
 end

--- a/app/controllers/concerns/handle_empty_email.rb
+++ b/app/controllers/concerns/handle_empty_email.rb
@@ -15,11 +15,9 @@ module HandleEmptyEmail
       super(documents)
     rescue Net::ReadTimeout => e
       sleep 3
-      if (retries += 1) < 2
-        retry
-      else
-        Honeybadger.notify e
-      end
+      raise e if (retries += 1) > 2
+
+      retry
     end
   end
 

--- a/app/controllers/concerns/handle_empty_email.rb
+++ b/app/controllers/concerns/handle_empty_email.rb
@@ -1,16 +1,34 @@
-
+# This module overrides Blacklight's mail-sending methods to only
+# actually send an email if there are documents selected.
+# MK 9/2020 - Why? Dunno. Maybe crawlers hit the urls and this was throwing
+# exceptions?
 module HandleEmptyEmail
 
   extend ActiveSupport::Concern
 
-  # override
+  # override of method in Blacklight::Catalog
   def email_action(documents)
-      super(documents) if documents.length > 0
+    return unless documents.any?
+
+    begin
+      retries ||= 0
+      super(documents)
+    rescue Net::ReadTimeout => e
+      sleep 3
+      if (retries += 1) < 2
+        retry
+      else
+        Honeybadger.notify e
+      end
+    end
   end
 
-  # override
+  # override of method in Blacklight::Catalog
+  # Note: Penn seems to have disabled the links to send a SMS
   def sms_action(documents)
-      super(documents) if documents.length > 0
+    return unless documents.any?
+
+    super(documents)
   end
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module Blacklight
 
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {
-      address: 'mailrelay.library.upenn.int',
+      address: 'mailrelay.library.upenn.int'
     }
     config.action_mailer.default_options = { from: 'no-reply@upenn.edu' }
 


### PR DESCRIPTION
This PR addresses two common mailer-related exceptions surfaced by Honeybadger:

1. [https://app.honeybadger.io/projects/75717/faults/67914397](https://app.honeybadger.io/projects/75717/faults/67914397): timeout from SMTP server - not sure why this occurs, but most of these exceptions appear to be due to spamming attempts. I introduce a `sleep` and `retry` (up to 2 times) and only then will notify Honeybadger.
2. [https://app.honeybadger.io/projects/75717/faults/67914284](https://app.honeybadger.io/projects/75717/faults/67914284): Bad email addresses when sending emails. I introduce a RegEx check for the `to:` address prior to proceeding with sending.