### PR TITLE
pre-filter "page" and "per_page"/"rows" params more consistently

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -818,7 +818,7 @@ class CatalogController < ApplicationController
 
   def limit_facet_pagination
     if params['facet.page'] && params['facet.page'].to_i > FACET_PAGINATION_THRESHOLD
-      flash[:error] = "You have paginated too deep into facets. Please contact us if you have a need to view facets past page #{FACET_PAGINATION_THRESHOLD}."
+      flash[:error] = "You have paginated too deep into facets. Please contact us if you need to view facets past page #{FACET_PAGINATION_THRESHOLD}."
       redirect_to root_path
     end
   end
@@ -832,7 +832,7 @@ class CatalogController < ApplicationController
       flash[:error] = "Request exceeds maximum number of records per page: #{blacklight_config.max_per_page}."
       redirect_to root_path
     elsif ((params[:page]&.to_i || 1) * per_page) > PAGINATION_THRESHOLD
-      flash[:error] = "You have paginated too deep into the result set. Please contact us if you have a need to view results past page #{PAGINATION_THRESHOLD}."
+      flash[:error] = "You have paginated too deep into the result set. Please contact us if you need to view results past record #{PAGINATION_THRESHOLD}."
       redirect_to root_path
     end
   end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -4,87 +4,27 @@ require 'uri'
 # frozen_string_literal: true
 class CatalogController < ApplicationController
   include ReplaceInvalidBytes
-
   include BlacklightAdvancedSearch::Controller
-
   include Blacklight::Catalog
   include Blacklight::Marc::Catalog
   include Blacklight::Ris::Catalog
-
   include BlacklightSolrplugins::XBrowse
-
   include HandleInvalidAdvancedSearch
-
   include AssociateExpandedDocs
-
   include HandleEmptyEmail
 
+  # expire session if needed
   before_action :expire_session
 
-  SECONDS_PER_DAY = 86400
+  # establish an effective "record depth" beyond which pagination is not supported
+  PAGINATION_THRESHOLD = 1000
+  before_action :limit_pagination, only: :index
 
-  def has_shib_session?
-    session[:alma_sso_user].present?
-  end
+  # and also for facets
+  FACET_PAGINATION_THRESHOLD = 50
+  before_action :limit_facet_pagination, only: :facet
 
-  def shib_session_valid?
-    session[:alma_sso_user] == request.headers['HTTP_REMOTE_USER']
-  end
-
-  # should return true if page isn't protected behind Shib
-  def is_unprotected_url?
-    true
-  end
-
-  def expire_shib_session_return_url
-    is_unprotected_url? ? request.original_url : root_url
-  end
-
-  def search_results(user_params)
-    sid = session&.id
-    if !sid.nil? && sid.length >= 8
-      routingHash = [sid[-8..-1]].pack("H*").unpack("l>")[0]
-      # mod 12 to support even distribution for replication
-      # factors 1,2,3,4; that should be sufficient for all
-      # practical cases.
-      user_params[:routingHash] = routingHash % 12
-    end
-    super
-  end
-
-  # manually expire the session if user has exceeded 'hard expiration' or if
-  # shib session has become inactive
-  def expire_session
-    invalid_shib = has_shib_session? && !shib_session_valid?
-    if (session[:hard_expiration] && session[:hard_expiration] < Time.now.to_i) || invalid_shib
-      reset_session
-      url = invalid_shib ? "/Shibboleth.sso/Logout?return=#{URI.encode(expire_shib_session_return_url)}" : expire_shib_session_return_url
-      redirect_to url, alert: 'Your session has expired, please log in again'
-    end
-  end
-
-  PAGINATION_THRESHOLD=1000 # effective "record depth" beyond which pagination is not supported
-  before_action only: :index do
-    per_page = (params[:per_page] || params[:rows])&.to_i || blacklight_config.default_per_page
-    if (per_page > blacklight_config.max_per_page)
-      # somebody's hacking the url; they're not going to get more than MAX_PER_PAGE records anyway, so give them an error.
-      # if it's a real person, they can resubmit the request and get what they would have gotten anyway; but don't jump through
-      # hoops to return records to what's most likely an overly-curious crawler
-      flash[:error] = "Request exceeds maximum number of records per page: #{blacklight_config.max_per_page}."
-      redirect_to root_path
-    elsif ((params[:page]&.to_i || 1) * per_page) > PAGINATION_THRESHOLD
-      flash[:error] = "You have paginated too deep into the result set. Please contact us if you have a need to view results past page #{PAGINATION_THRESHOLD}."
-      redirect_to root_path
-    end
-  end
-
-  FACET_PAGINATION_THRESHOLD=50
-  before_action only: :facet do
-    if params['facet.page'] && params['facet.page'].to_i > FACET_PAGINATION_THRESHOLD
-      flash[:error] = "You have paginated too deep into facets. Please contact us if you have a need to view facets past page #{FACET_PAGINATION_THRESHOLD}."
-      redirect_to root_path
-    end
-  end
+  SECONDS_PER_DAY = 86_400
 
   configure_blacklight do |config|
     # default advanced config values
@@ -821,17 +761,6 @@ class CatalogController < ApplicationController
     config.navbar.partials.delete(:search_history)
   end
 
-  # override from Blacklight::Marc::Catalog so that action appears on bookmarks page
-  def render_refworks_action? config, options = {}
-    doc = options[:document] || (options[:document_list] || []).first
-    doc && doc.respond_to?(:export_formats) && doc.export_formats.keys.include?(:refworks_marc_txt)
-  end
-
-  def render_saved_searches?
-    # don't ever show saved searches link to the user
-    false
-  end
-
   # extend 'index' so we can override views
   def bento
     index
@@ -842,6 +771,81 @@ class CatalogController < ApplicationController
   def landing
     @page_title = t('franklin.landing_page_title')
     index
+  end
+
+  # override
+  def search_results(user_params)
+    sid = session&.id
+    if !sid.nil? && sid.length >= 8
+      routingHash = [sid[-8..-1]].pack("H*").unpack("l>")[0]
+      # mod 12 to support even distribution for replication
+      # factors 1,2,3,4; that should be sufficient for all
+      # practical cases.
+      user_params[:routingHash] = routingHash % 12
+    end
+    super
+  end
+
+  private
+
+  def has_shib_session?
+    session[:alma_sso_user].present?
+  end
+
+  def shib_session_valid?
+    session[:alma_sso_user] == request.headers['HTTP_REMOTE_USER']
+  end
+
+  # should return true if page isn't protected behind Shib
+  def is_unprotected_url?
+    true
+  end
+
+  def expire_shib_session_return_url
+    is_unprotected_url? ? request.original_url : root_url
+  end
+
+  # manually expire the session if user has exceeded 'hard expiration' or if
+  # shib session has become inactive
+  def expire_session
+    invalid_shib = has_shib_session? && !shib_session_valid?
+    if (session[:hard_expiration] && session[:hard_expiration] < Time.now.to_i) || invalid_shib
+      reset_session
+      url = invalid_shib ? "/Shibboleth.sso/Logout?return=#{URI.encode(expire_shib_session_return_url)}" : expire_shib_session_return_url
+      redirect_to url, alert: 'Your session has expired, please log in again'
+    end
+  end
+
+  def limit_facet_pagination
+    if params['facet.page'] && params['facet.page'].to_i > FACET_PAGINATION_THRESHOLD
+      flash[:error] = "You have paginated too deep into facets. Please contact us if you have a need to view facets past page #{FACET_PAGINATION_THRESHOLD}."
+      redirect_to root_path
+    end
+  end
+
+  def limit_pagination
+    per_page = (params[:per_page] || params[:rows])&.to_i || blacklight_config.default_per_page
+    if per_page > blacklight_config.max_per_page
+      # somebody's hacking the url; they're not going to get more than MAX_PER_PAGE records anyway, so give them an error.
+      # if it's a real person, they can resubmit the request and get what they would have gotten anyway; but don't jump through
+      # hoops to return records to what's most likely an overly-curious crawler
+      flash[:error] = "Request exceeds maximum number of records per page: #{blacklight_config.max_per_page}."
+      redirect_to root_path
+    elsif ((params[:page]&.to_i || 1) * per_page) > PAGINATION_THRESHOLD
+      flash[:error] = "You have paginated too deep into the result set. Please contact us if you have a need to view results past page #{PAGINATION_THRESHOLD}."
+      redirect_to root_path
+    end
+  end
+
+  # override from Blacklight::Marc::Catalog so that action appears on bookmarks page
+  def render_refworks_action?(config, options = {})
+    doc = options[:document] || (options[:document_list] || []).first
+    doc && doc.respond_to?(:export_formats) && doc.export_formats.keys.include?(:refworks_marc_txt)
+  end
+
+  def render_saved_searches?
+    # don't ever show saved searches link to the user
+    false
   end
 
 end


### PR DESCRIPTION
the relevant limit should be on the record-based effective
paging depth, not arbitrarily on the size of the "page" param
itself. Also, while we're inspecting, let's shortcircuit BL's
attempts to be tolerant in parsing the per_page param