### PR TITLE
Allow simulating logged in users via DEVELOPMENT_USERNAME

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,10 @@ class ApplicationController < ActionController::Base
   include Blacklight::Controller
   layout 'blacklight'
 
+  # Allow developers to simulate HTTP_REMOTE_USER using
+  # DEVELOPMENT_USERNAME env var
+  before_action :set_dev_user_header
+
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
@@ -40,4 +44,10 @@ class ApplicationController < ActionController::Base
     render :template => "/known_issues"
   end
 
+  # Sets HTTP_REMOTE_USER value for development use
+  def set_dev_user_header
+    if Rails.env.development?
+      request.headers['HTTP_REMOTE_USER'] = ENV['DEVELOPMENT_USERNAME']
+    end
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -57,9 +57,17 @@ class SessionsController < Devise::SessionsController
     # adjust this to be deliberately lower.
     session['hard_expiration'] = Time.now.to_i + (10 * 60 * 60)
 
+    # TODO: this can lead to 'none' being set as the session userid
+    # which breaks some Alma lookups for guest users. Removing this
+    # and not setting session user info for guest users is probably
+    # the right thing to do but needs testing in a production-like
+    # environment
     remote_user_header = request.headers['HTTP_REMOTE_USER'] || 'none@upenn.edu'
-
-    pennkey_username = remote_user_header.split('@').first
+    pennkey_username = if Rails.env.production?
+                         remote_user_header.split('@').first
+                       else
+                         ENV['DEVELOPMENT_USERNAME']
+                       end
     set_session_user_details(pennkey_username)
     set_session_userid(pennkey_username)
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -63,11 +63,7 @@ class SessionsController < Devise::SessionsController
     # the right thing to do but needs testing in a production-like
     # environment
     remote_user_header = request.headers['HTTP_REMOTE_USER'] || 'none@upenn.edu'
-    pennkey_username = if Rails.env.production?
-                         remote_user_header.split('@').first
-                       else
-                         ENV['DEVELOPMENT_USERNAME']
-                       end
+    pennkey_username = remote_user_header.split('@').first
     set_session_user_details(pennkey_username)
     set_session_userid(pennkey_username)
   end


### PR DESCRIPTION
This is useful in development and test to work with authenticated-only features and with Alma API lookups that include the username of the logged-in user (holding details, etc)