### PR TITLE
Replace Tool Panel with Toolbar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'uglifier', '3.0.2'
 group :development do
   gem 'dotenv-rails'
   gem 'web-console', '~> 2.0', platforms: :ruby
+  gem 'xray-rails'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,6 +328,8 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    xray-rails (0.3.2)
+      rails (>= 3.1.0)
     yell (2.2.2)
 
 PLATFORMS
@@ -367,6 +369,7 @@ DEPENDENCIES
   tzinfo-data (= 1.2017.2)
   uglifier (= 3.0.2)
   web-console (~> 2.0)
+  xray-rails
 
 BUNDLED WITH
    1.17.3

--- a/app/views/catalog/_show_header_default.html.erb
+++ b/app/views/catalog/_show_header_default.html.erb
@@ -1,0 +1,35 @@
+<% # bookmark/folder functions -%>
+<div class="row">
+  <div class="col-md-7">
+    <%= render_document_heading(document, :tag => :h1) %>
+  </div>
+  <div class="col-md-5">
+    <div class="btn-toolbar pull-right" role="toolbar" aria-label="">
+<!--      <button type="button" class="btn btn-default"><%#= render 'bookmark_control', document: @document %></button>-->
+      <button type="button" class="btn btn-default">Bookmark</button>
+      <div class="btn-group" role="group">
+        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Share
+          <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu">
+          <li><a href="#">Print</a></li>
+          <li><a href="#">Mail</a></li>
+          <li><a href="#">Cite</a></li>
+        </ul>
+      </div>
+      <div class="btn-group" role="group">
+        <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Export
+          <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu">
+          <li><a href="#">To RefWorks</a></li>
+          <li><a href="#">To EndNote</a></li>
+          <li><a href="#">In RIS Format</a></li>
+        </ul>
+      </div>
+      <button type="button" class="btn btn-default">Staff View</button>
+    </div>
+  </div>
+</div>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,0 +1,7 @@
+<div id="content" class="col-md-12">
+  <%= render_document_main_content_partial %>
+</div>
+
+<!--<div id="sidebar" class="<%#= show_sidebar_classes %>">-->
+  <%#= render_document_sidebar_partial %>
+<!--</div>-->


### PR DESCRIPTION
This replaces the tools panel on a record show page with a toolbar.

Currently:

![image](https://user-images.githubusercontent.com/4390340/99723497-4367f900-2a80-11eb-93d2-d194fa73c240.png)

The tools panel exists in it's own column, which limits the width of our availability widget. This change is more economical with space.

Proposed:

![image](https://user-images.githubusercontent.com/4390340/99723750-93df5680-2a80-11eb-9e93-5267b0941d4d.png)

This is a common change made by peer institutions using Blacklight:

Princeton: https://catalog.princeton.edu/catalog/11109433
PSU: https://catalog.libraries.psu.edu/catalog/3689597

Note: Buttons on this branch are non-functional, this is only a PoC so far.